### PR TITLE
fix(playerstatus): display health correctly

### DIFF
--- a/modules/threads/client/player_status.lua
+++ b/modules/threads/client/player_status.lua
@@ -79,7 +79,7 @@ function PlayerStatusThread:start(vehicleStatusThread, seatbeltLogic, framework)
             end
 
             local pedArmor = GetPedArmour(ped)
-            local pedHealthUnrestricted = math.floor(GetEntityHealth(ped) / GetEntityMaxHealth(ped) * 100)
+            local pedHealthUnrestricted = math.floor(GetEntityHealth(ped) - 100)
             local pedHealth = math.max(0, math.min(pedHealthUnrestricted, 100))
             local pedHunger = framework and framework:getPlayerHunger() or nil
             local pedThirst = framework and framework:getPlayerThirst() or nil


### PR DESCRIPTION
Changes health to show from 1/100 instead of dying at 50%. 