### PR TITLE
fix(vehiclestatus): don't assume GetVehicleLightsState returns booleans

### DIFF
--- a/modules/threads/client/vehicle_status.lua
+++ b/modules/threads/client/vehicle_status.lua
@@ -97,7 +97,7 @@ function VehicleStatusThread:start()
             end
 
             -- Vehicle headlights
-            local headlights = (lightsOn and highbeamsOn) and 100 or (lightsOn or highbeamsOn) and 50 or 0
+            local headlights = (highbeamsOn == 1) and 100 or (lightsOn == 1) and 50 or 0
 
             interface:message("state::vehicle::set", {
                 speedUnit = config.speedUnit,


### PR DESCRIPTION
Currently the VehicleStatusThread assumes that the return values of GetVehicleLightsState are booleans, but they are in fact integers. This results in the light status bar never changing as expected.

This PR resolves this issue and also simplifies the logic used to set the headlights value. 